### PR TITLE
feat(#16): add a Makefile to automate local tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all test distclean
+
+CMD = cargo
+BUILD = build --release
+FORMAT = fmt --check
+CLIPPY = clippy --all
+TEST = test --all
+
+SOURCES = $(wildcard **/*.rs)
+TESTS = $(wildcard **/*.rs)
+TARGET = target/release/libnprint_rs.rlib
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	$(CMD) $(BUILD)
+
+test: $(TARGET)
+	$(CMD) $(FORMAT) && \
+	$(CMD) $(CLIPPY) && \
+	$(CMD) $(TEST)
+
+distclean:
+	rm -rf target Cargo.lock


### PR DESCRIPTION
## PR is ready as far as I'm concerned.

## What it does

This PR adds a `Makefile` at the root of the project, to ease testing the local repo.
Mainly, it provides a reproducible `test` target.
It also provides a `distclean` target to cleanup the tree.

## Other comments

In the future, this file could be used to have similar pipelines when building locally vs in CI/CD. 