### PR TITLE
Switch pub crate module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nprint-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Johann Hugon <nprint-rs@johannhugon.com>","David Julien"]
 description = "Rust adaptation of Nprint"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! nPrint is a standard data representation for network traffic, designed for direct use with machine learning algorithms, eliminating the need for feature engineering in various traffic analysis tasks. Developing a Rust implementation of nPrint will simplify the creation of network systems that leverage real-world ML deployments, rather than just training and deploying models offline.
-pub mod protocols;
+pub(crate) mod protocols;
 use crate::protocols::ipv4::Ipv4Header;
 use crate::protocols::packet::PacketHeader;
 use crate::protocols::tcp::TcpHeader;


### PR DESCRIPTION
We need to switch the module to pub(crate) as we don't need it to be used outside.